### PR TITLE
test(node-js): add unit tests for controller command logic; fix DriveValue.read rounding

### DIFF
--- a/controller/node-js/package.json
+++ b/controller/node-js/package.json
@@ -10,7 +10,8 @@
     "dev:server": "npm run start --prefix server",
     "dev:start-client": "vite --port 8081 --host",
     "build": "vite build",
-    "lint": "eslint server/*.js --fix && eslint client/*.js --fix"
+    "lint": "eslint server/*.js --fix && eslint client/*.js --fix",
+    "test": "node --test"
   },
   "author": "Ivo Zivkov",
   "devDependencies": {

--- a/controller/node-js/server/commands.js
+++ b/controller/node-js/server/commands.js
@@ -42,7 +42,7 @@ function DriveValue () {
   }
 
   this.read = () => {
-    return Math.round(value, 3)
+    return Math.round(value * 1000) / 1000
   }
 }
 
@@ -121,4 +121,4 @@ function DriveCommandReducer () {
   }
 }
 
-module.exports = { Commands, CommandHandler }
+module.exports = { Commands, CommandHandler, DriveValue }

--- a/controller/node-js/test/commands.test.js
+++ b/controller/node-js/test/commands.test.js
@@ -1,0 +1,97 @@
+/*
+ * Unit tests for the OpenBot node-js controller command logic.
+ *
+ * These exercise the pure server-side command mapping that ultimately drives
+ * the robot's left/right motors, so a regression here could send wrong motor
+ * commands. Run with: `npm test` (uses Node's built-in test runner).
+ */
+
+const test = require('node:test')
+const assert = require('node:assert')
+
+const { Commands, DriveValue } = require('../server/commands.js')
+
+// Creates a CommandHandler and captures every command string it sends.
+function makeHandler () {
+  const sent = []
+  const commands = new Commands(msg => sent.push(msg))
+  return { handler: commands.getCommandHandler(), sent }
+}
+
+test('goForward sends full forward drive command', () => {
+  const { handler, sent } = makeHandler()
+  handler.goForward()
+  assert.deepStrictEqual(JSON.parse(sent[0]), { driveCmd: { l: 1, r: 1 } })
+})
+
+test('goBackward sends full reverse drive command', () => {
+  const { handler, sent } = makeHandler()
+  handler.goBackward()
+  assert.deepStrictEqual(JSON.parse(sent[0]), { driveCmd: { l: -1, r: -1 } })
+})
+
+test('forwardLeft mixes left/right correctly', () => {
+  const { handler, sent } = makeHandler()
+  handler.forwardLeft()
+  assert.deepStrictEqual(JSON.parse(sent[0]), { driveCmd: { l: -0.5, r: 1 } })
+})
+
+test('forwardRight mixes right/left correctly', () => {
+  const { handler, sent } = makeHandler()
+  handler.forwardRight()
+  assert.deepStrictEqual(JSON.parse(sent[0]), { driveCmd: { l: 1, r: -0.5 } })
+})
+
+test('rotateLeft / rotateRight send opposing wheel commands', () => {
+  const { handler, sent } = makeHandler()
+  handler.rotateLeft()
+  assert.deepStrictEqual(JSON.parse(sent[0]), { driveCmd: { l: -1, r: 1 } })
+
+  const { handler: handler2, sent: sent2 } = makeHandler()
+  handler2.rotateRight()
+  assert.deepStrictEqual(JSON.parse(sent2[0]), { driveCmd: { l: 1, r: -1 } })
+})
+
+test('reset sends a zero drive command', () => {
+  const { handler, sent } = makeHandler()
+  handler.reset()
+  assert.deepStrictEqual(JSON.parse(sent[0]), { driveCmd: { l: 0, r: 0 } })
+})
+
+test('consecutive identical drive commands are de-duplicated', () => {
+  const { handler, sent } = makeHandler()
+  handler.goForward()
+  handler.goForward()
+  handler.goForward()
+  assert.strictEqual(sent.length, 1)
+})
+
+test('different drive commands are each sent', () => {
+  const { handler, sent } = makeHandler()
+  handler.goForward()
+  handler.goBackward()
+  assert.strictEqual(sent.length, 2)
+})
+
+test('sendCommand forwards the raw command string', () => {
+  const { handler, sent } = makeHandler()
+  handler.sendCommand('NOISE')
+  assert.strictEqual(sent[0], '{command: NOISE }')
+})
+
+test('DriveValue clamps to [-1, 1] and read() rounds to 3 decimals', () => {
+  const dv = new DriveValue()
+  assert.strictEqual(dv.reset(), 0)
+  assert.strictEqual(dv.min(), -1)
+  assert.strictEqual(dv.max(), 1)
+
+  // Before the fix this returned Math.round(0.12345) === 0 (2nd arg ignored).
+  dv.write(0.12345)
+  assert.strictEqual(dv.read(), 0.123)
+
+  dv.write(0.9999)
+  assert.strictEqual(dv.read(), 1)
+
+  dv.write(-0.4567)
+  assert.strictEqual(dv.read(), -0.457)
+})


### PR DESCRIPTION
## Summary

The node-js web controller has no automated tests for its server-side command logic, even though that logic computes the exact left/right motor commands sent to the robot. This PR adds dependency-free unit tests and fixes a latent rounding bug found while writing them.

- **New tests** (`controller/node-js/test/commands.test.js`, run via Node's built-in `node:test`):
  - `CommandHandler` drive mapping for `goForward` / `goBackward` / `forwardLeft` / `forwardRight` / `rotateLeft` / `rotateRight` / `reset`.
  - `DriveCommandReducer` de-duplication (identical consecutive drive commands are not re-sent).
  - `CommandHandler.sendCommand` raw-command forwarding.
  - `DriveValue` clamping to [-1, 1] and `read()` precision.
- **Bug fix**: `DriveValue.read()` used `Math.round(value, 3)`. `Math.round` only accepts one argument, so the `3` was ignored and the method returned an **integer** instead of a 3-decimal value. Changed to `Math.round(value * 1000) / 1000`. `DriveValue` is now exported so the tests can reach it. Note: `read()` isn't currently called anywhere in `server/` or `client/` (the drive-command path uses the raw `.min()`/`.max()`/`.write()` values directly), so this fix doesn't change any live behavior today, it's a correctness fix to a previously-unused method, now exercised by this PR's own tests.
- Added a `"test": "node --test"` script to `controller/node-js/package.json` (zero new dependencies; runs on Node 18+).

## Why this matters

The `CommandHandler` drive mapping tested here is the code that computes the actual left/right motor commands sent to the robot, so a regression there would silently send wrong motor commands to a physical robot. The new tests lock in that expected behavior and run in CI-friendly, dependency-free fashion.

## Test plan

- [x] `cd controller/node-js && npm test` → 10/10 passing on Node 22 (also verified with `node --check` on all `server/*.js` and `client/*.js`).
- [x] Regression check: reverting the `read()` fix makes the `DriveValue` test fail (proving the test actually guards the fix).

## Notes

This is unrelated to #447 / PR #514 (the TF/Keras policy-training issue), which is handled separately.

🤖 Generated with WorkBuddy
