### PR TITLE
Fix BLE transport initialization

### DIFF
--- a/android/robot/src/main/java/org/openbot/app/robot/OpenBotApplication.java
+++ b/android/robot/src/main/java/org/openbot/app/robot/OpenBotApplication.java
@@ -28,7 +28,6 @@ public class OpenBotApplication extends Application {
     vehicle = new Vehicle(this, baudRate);
     vehicle.initBle();
     vehicle.connectUsb();
-    vehicle.initBle();
     if (BuildConfig.DEBUG) {
       Timber.plant(
           new Timber.DebugTree() {

--- a/android/robot/src/main/java/org/openbot/app/robot/vehicle/BluetoothManager.java
+++ b/android/robot/src/main/java/org/openbot/app/robot/vehicle/BluetoothManager.java
@@ -25,6 +25,9 @@ import org.openbot.app.robot.main.ScanDeviceAdapter;
 import org.openbot.app.robot.utils.Constants;
 
 public class BluetoothManager {
+  private static final String SERVICE_UUID = "61653dc3-4021-4d1e-ba83-8b4eec61d613";
+  private static final String RX_UUID = "06386c14-86ea-4d71-811c-48f97c58f8c9";
+  private static final String TX_UUID = "9bf1103b-834c-47cf-b149-c9e4bcf778a7";
   private BleManager manager;
   private CharacteristicInfo notifyCharacteristic;
   private CharacteristicInfo writeCharacteristic;
@@ -38,8 +41,8 @@ public class BluetoothManager {
   private int indexValue;
   public String readValue;
   private final LocalBroadcastManager localBroadcastManager;
-  private String serviceUUID = "61653dc3-4021-4d1e-ba83-8b4eec61d613";
-  UUID[] uuidArray = new UUID[] {UUID.fromString(serviceUUID)};
+  private boolean notifyEnabled;
+  UUID[] uuidArray = new UUID[] {UUID.fromString(SERVICE_UUID)};
 
   public BluetoothManager(Context context) {
     this.context = context;
@@ -81,7 +84,7 @@ public class BluetoothManager {
               }
             }
             deviceList.add(device);
-            adapter.notifyDataSetChanged();
+            notifyAdapter();
           }
 
           @Override
@@ -97,7 +100,7 @@ public class BluetoothManager {
 
           @Override
           public void onFinish() {
-            adapter.notifyDataSetChanged();
+            notifyAdapter();
           }
         });
   }
@@ -123,10 +126,11 @@ public class BluetoothManager {
       new BleConnectCallback() {
         @Override
         public void onStart(boolean startConnectSuccess, String info, BleDevice device) {
+          clearSerialState();
           bleDevice = device;
           deviceList.remove(indexValue);
           deviceList.add(indexValue, device);
-          adapter.notifyDataSetChanged();
+          notifyAdapter();
         }
 
         @Override
@@ -134,55 +138,60 @@ public class BluetoothManager {
           bleDevice = device;
           deviceList.remove(indexValue);
           deviceList.add(indexValue, device);
-          adapter.notifyDataSetChanged();
+          notifyAdapter();
           addDeviceInfoDataAndUpdate();
           Logger.i("Successfully connected: " + " " + device);
         }
 
         @Override
         public void onDisconnected(String info, int status, BleDevice device) {
+          clearSerialState();
           bleDevice = null;
-          adapter.notifyDataSetChanged();
+          notifyAdapter();
           Logger.i("disconnected!");
         }
 
         @Override
         public void onFailure(int failCode, String info, BleDevice device) {
           Logger.e("connect fail:" + info);
+          clearSerialState();
           bleDevice = null;
           deviceList.remove(indexValue);
           deviceList.add(indexValue, device);
           Toast.makeText(context, "Connection fail: " + info, Toast.LENGTH_LONG).show();
-          adapter.notifyDataSetChanged();
+          notifyAdapter();
         }
       };
 
   public void addDeviceInfoDataAndUpdate() {
     if (bleDevice == null) return;
+    clearSerialState();
     Map<ServiceInfo, List<CharacteristicInfo>> deviceInfo =
         BleManager.getInstance().getDeviceServices(bleDevice.address);
     if (deviceInfo == null) {
       return;
     }
     for (Map.Entry<ServiceInfo, List<CharacteristicInfo>> e : deviceInfo.entrySet()) {
+      if (!SERVICE_UUID.equalsIgnoreCase(e.getKey().uuid)) continue;
       for (CharacteristicInfo characteristicInfo : e.getValue()) {
-        if (characteristicInfo.notify) {
+        if (TX_UUID.equalsIgnoreCase(characteristicInfo.uuid) && characteristicInfo.notify) {
           notifyCharacteristic = characteristicInfo;
           notifyServiceInfo = e.getKey();
-          if (isBleConnected())
-            // Set the MTU size to 64 bytes
-            BleManager.getInstance().setMtu(bleDevice, 64, mtuCallback);
         }
-        if (characteristicInfo.writable) {
+        if (RX_UUID.equalsIgnoreCase(characteristicInfo.uuid) && characteristicInfo.writable) {
           writeServiceInfo = e.getKey();
           writeCharacteristic = characteristicInfo;
         }
       }
     }
+    if (isBleConnected() && hasSerialCharacteristics()) {
+      // Set the MTU size to 64 bytes before enabling UART notifications.
+      BleManager.getInstance().setMtu(bleDevice, 64, mtuCallback);
+    }
   }
 
   public void write(String msg) {
-    if (isBleConnected()) {
+    if (isSerialReady() && msg != null) {
       BleManager.getInstance()
           .write(
               bleDevice,
@@ -197,13 +206,17 @@ public class BluetoothManager {
       new BleMtuCallback() {
         @Override
         public void onMtuChanged(int mtu, BleDevice device) {
-          BleManager.getInstance()
-              .notify(bleDevice, notifyServiceInfo.uuid, notifyCharacteristic.uuid, notifyCallback);
+          if (isBleConnected() && hasSerialCharacteristics()) {
+            BleManager.getInstance()
+                .notify(
+                    bleDevice, notifyServiceInfo.uuid, notifyCharacteristic.uuid, notifyCallback);
+          }
         }
 
         @Override
         public void onFailure(int failCode, String info, BleDevice device) {
           Logger.e("mtu fail:" + info + " " + failCode);
+          clearSerialState();
         }
       };
   public BleWriteCallback writeCallback =
@@ -224,7 +237,7 @@ public class BluetoothManager {
       new BleNotifyCallback() {
         @Override
         public void onCharacteristicChanged(byte[] data, BleDevice device) {
-          readValue = new String(data);
+          readValue = new String(data, UTF_8);
           onSerialDataReceived(readValue);
         }
 
@@ -233,11 +246,13 @@ public class BluetoothManager {
           if (!notifySuccessUuids.contains(notifySuccessUuid)) {
             notifySuccessUuids.add(notifySuccessUuid);
           }
+          if (TX_UUID.equalsIgnoreCase(notifySuccessUuid)) notifyEnabled = true;
         }
 
         @Override
         public void onFailure(int failCode, String info, BleDevice device) {
           Logger.e("notify fail:" + info);
+          clearSerialState();
         }
       };
 
@@ -245,12 +260,36 @@ public class BluetoothManager {
     return bleDevice != null && bleDevice.connected;
   }
 
+  public boolean isSerialReady() {
+    return isBleConnected() && hasSerialCharacteristics() && notifyEnabled;
+  }
+
+  private boolean hasSerialCharacteristics() {
+    return writeServiceInfo != null
+        && writeCharacteristic != null
+        && notifyServiceInfo != null
+        && notifyCharacteristic != null;
+  }
+
+  private void clearSerialState() {
+    writeServiceInfo = null;
+    writeCharacteristic = null;
+    notifyServiceInfo = null;
+    notifyCharacteristic = null;
+    notifySuccessUuids.clear();
+    notifyEnabled = false;
+  }
+
+  private void notifyAdapter() {
+    if (adapter != null) adapter.notifyDataSetChanged();
+  }
+
   private void onSerialDataReceived(String data) {
     // Add whatever you want here
     Logger.i("Serial data received from BLE: " + data);
     localBroadcastManager.sendBroadcast(
         new Intent(Constants.DEVICE_ACTION_DATA_RECEIVED)
-            .putExtra("from", "usb")
+            .putExtra("from", "ble")
             .putExtra("data", data));
   }
 }

--- a/android/robot/src/main/java/org/openbot/app/robot/vehicle/Vehicle.java
+++ b/android/robot/src/main/java/org/openbot/app/robot/vehicle/Vehicle.java
@@ -508,6 +508,7 @@ public class Vehicle {
   }
 
   public void initBle() {
+    if (bluetoothManager != null) return;
     bluetoothManager = new BluetoothManager(context);
   }
 

--- a/android/robot/src/test/java/org/openbot/app/robot/vehicle/BluetoothManagerTest.java
+++ b/android/robot/src/test/java/org/openbot/app/robot/vehicle/BluetoothManagerTest.java
@@ -1,0 +1,225 @@
+package org.openbot.app.robot.vehicle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Looper;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import com.ficat.easyble.BleDevice;
+import com.ficat.easyble.BleManager;
+import com.ficat.easyble.gatt.bean.CharacteristicInfo;
+import com.ficat.easyble.gatt.bean.ServiceInfo;
+import com.ficat.easyble.gatt.callback.BleMtuCallback;
+import com.ficat.easyble.gatt.callback.BleNotifyCallback;
+import com.ficat.easyble.gatt.callback.BleWriteCallback;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openbot.app.robot.utils.Constants;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28, shadows = BluetoothManagerTest.FakeBleManager.class)
+public class BluetoothManagerTest {
+  private static final String SERVICE_UUID = "61653dc3-4021-4d1e-ba83-8b4eec61d613";
+  private static final String RX_UUID = "06386c14-86ea-4d71-811c-48f97c58f8c9";
+  private static final String TX_UUID = "9bf1103b-834c-47cf-b149-c9e4bcf778a7";
+
+  private BluetoothManager bluetoothManager;
+  private FakeBleManager transport;
+  private BleDevice device;
+
+  @Before
+  public void setUp() {
+    ReflectionHelpers.setStaticField(BleManager.class, "instance", null);
+    bluetoothManager = new BluetoothManager(RuntimeEnvironment.getApplication());
+    transport = Shadow.extract(BleManager.getInstance());
+    device = createDevice("8C:94:DF:A1:CC:A6");
+    device.connected = true;
+    bluetoothManager.bleDevice = device;
+  }
+
+  @Test
+  public void usesOnlyOfficialOpenBotUartCharacteristics() {
+    ServiceInfo unrelatedService = new ServiceInfo("0000180f-0000-1000-8000-00805f9b34fb");
+    ServiceInfo uartService = new ServiceInfo(SERVICE_UUID);
+    transport.services = new LinkedHashMap<>();
+    transport.services.put(
+        unrelatedService,
+        Arrays.asList(
+            new CharacteristicInfo("unrelated-write", false, true, false, false),
+            new CharacteristicInfo("unrelated-notify", false, false, true, false)));
+    transport.services.put(
+        uartService,
+        Arrays.asList(
+            new CharacteristicInfo(TX_UUID, false, false, true, false),
+            new CharacteristicInfo(RX_UUID, false, true, false, false)));
+
+    bluetoothManager.addDeviceInfoDataAndUpdate();
+
+    assertEquals(1, transport.mtuRequests);
+    assertFalse(bluetoothManager.isSerialReady());
+    bluetoothManager.mtuCallback.onMtuChanged(64, device);
+    assertEquals(SERVICE_UUID, transport.notifyServiceUuid);
+    assertEquals(TX_UUID, transport.notifyCharacteristicUuid);
+
+    bluetoothManager.notifyCallback.onNotifySuccess(TX_UUID, device);
+    assertTrue(bluetoothManager.isSerialReady());
+    bluetoothManager.write("c0,0\n");
+    assertEquals(1, transport.writes);
+    assertEquals(SERVICE_UUID, transport.writeServiceUuid);
+    assertEquals(RX_UUID, transport.writeCharacteristicUuid);
+  }
+
+  @Test
+  public void writeBeforeNotificationReadyIsIgnored() {
+    bluetoothManager.write("c0,0\n");
+    assertEquals(0, transport.writes);
+  }
+
+  @Test
+  public void notificationFailureClearsSerialReadyState() {
+    makeSerialReady();
+    assertTrue(bluetoothManager.isSerialReady());
+
+    bluetoothManager.notifyCallback.onFailure(1, "failed", device);
+
+    assertFalse(bluetoothManager.isSerialReady());
+    bluetoothManager.write("c0,0\n");
+    assertEquals(0, transport.writes);
+  }
+
+  @Test
+  public void disconnectClearsSerialReadyState() {
+    makeSerialReady();
+
+    bluetoothManager.connectCallback.onDisconnected("remote", 0, device);
+
+    assertFalse(bluetoothManager.isSerialReady());
+  }
+
+  @Test
+  public void receivedDataIdentifiesBleTransport() {
+    Context context = RuntimeEnvironment.getApplication();
+    Intent[] received = new Intent[1];
+    BroadcastReceiver receiver =
+        new BroadcastReceiver() {
+          @Override
+          public void onReceive(Context context, Intent intent) {
+            received[0] = intent;
+          }
+        };
+    LocalBroadcastManager broadcasts = LocalBroadcastManager.getInstance(context);
+    broadcasts.registerReceiver(receiver, new IntentFilter(Constants.DEVICE_ACTION_DATA_RECEIVED));
+
+    bluetoothManager.notifyCallback.onCharacteristicChanged("fDIY\n".getBytes(), device);
+    org.robolectric.Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+    assertEquals("ble", received[0].getStringExtra("from"));
+    assertEquals("fDIY\n", received[0].getStringExtra("data"));
+    broadcasts.unregisterReceiver(receiver);
+  }
+
+  @Test
+  public void vehicleBleInitializationIsIdempotent() {
+    Vehicle vehicle = new Vehicle(RuntimeEnvironment.getApplication(), 115200);
+    vehicle.initBle();
+    BluetoothManager first = ReflectionHelpers.getField(vehicle, "bluetoothManager");
+
+    vehicle.initBle();
+
+    assertSame(first, ReflectionHelpers.getField(vehicle, "bluetoothManager"));
+  }
+
+  private void makeSerialReady() {
+    ServiceInfo uartService = new ServiceInfo(SERVICE_UUID);
+    transport.services = new LinkedHashMap<>();
+    transport.services.put(
+        uartService,
+        Arrays.asList(
+            new CharacteristicInfo(TX_UUID, false, false, true, false),
+            new CharacteristicInfo(RX_UUID, false, true, false, false)));
+    bluetoothManager.addDeviceInfoDataAndUpdate();
+    bluetoothManager.notifyCallback.onNotifySuccess(TX_UUID, device);
+  }
+
+  private static BleDevice createDevice(String address) {
+    BluetoothDevice bluetoothDevice = BluetoothAdapter.getDefaultAdapter().getRemoteDevice(address);
+    return ReflectionHelpers.callConstructor(
+        BleDevice.class, ClassParameter.from(BluetoothDevice.class, bluetoothDevice));
+  }
+
+  @Implements(BleManager.class)
+  public static class FakeBleManager {
+    @RealObject BleManager realManager;
+    Map<ServiceInfo, List<CharacteristicInfo>> services = new LinkedHashMap<>();
+    int mtuRequests;
+    int writes;
+    String notifyServiceUuid;
+    String notifyCharacteristicUuid;
+    String writeServiceUuid;
+    String writeCharacteristicUuid;
+
+    @Implementation
+    protected static boolean supportBle(Context context) {
+      return true;
+    }
+
+    @Implementation
+    protected BleManager init(Context context) {
+      return realManager;
+    }
+
+    @Implementation
+    protected Map<ServiceInfo, List<CharacteristicInfo>> getDeviceServices(String address) {
+      return services;
+    }
+
+    @Implementation
+    protected void setMtu(BleDevice device, int mtu, BleMtuCallback callback) {
+      mtuRequests++;
+    }
+
+    @Implementation
+    protected void notify(
+        BleDevice device,
+        String serviceUuid,
+        String characteristicUuid,
+        BleNotifyCallback callback) {
+      notifyServiceUuid = serviceUuid;
+      notifyCharacteristicUuid = characteristicUuid;
+    }
+
+    @Implementation
+    protected void write(
+        BleDevice device,
+        String serviceUuid,
+        String characteristicUuid,
+        byte[] data,
+        BleWriteCallback callback) {
+      writes++;
+      writeServiceUuid = serviceUuid;
+      writeCharacteristicUuid = characteristicUuid;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- initialize the BLE manager only once
- select only the official OpenBot UART service, RX, and TX characteristics
- allow writes only after UART notifications are enabled and clear stale state on failures or disconnects
- label BLE receive broadcasts with `from="ble"` instead of `from="usb"`

## Why

The Android robot app initialized its BLE manager twice, selected any writable/notifiable characteristic exposed by a peripheral, and treated a physical BLE connection as immediately writable. This could replace connection state during startup, select characteristics outside the OpenBot UART service, or dereference missing characteristics before service and notification setup completed.

This is the transport-only follow-up requested in #523. It does not include cart-following code, custom firmware support, write queuing, reconnect behavior, or developer notes.

## Tests

- `./gradlew :robot:testDebugUnitTest` (11 tests, including 6 new BLE regression tests)
- `./gradlew :robot:assembleDebug`
- repository `google-java-format` check on all four changed Java files

The build emits the existing Android Gradle Plugin/compileSdk and D8 navigation warnings; both tasks complete successfully.